### PR TITLE
Fix: Update Railway CLI command syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,6 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway
-        run: railway up --project=25465eb5-0316-43b9-a8b4-c0f20668ac61 --service=76197fbe-c3a4-4358-ad81-75e8bd53afd3
+        run: railway up -s 76197fbe-c3a4-4358-ad81-75e8bd53afd3
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
This PR fixes the deployment issue by updating the Railway CLI command syntax. The Railway CLI command format has changed, and the current command in our workflow file was using incorrect syntax with --project= and --service=. According to the Railway CLI documentation, the correct format is to use the -s or --service flag followed by the service ID as a separate value. This change will allow our deployments to work again with the latest version of the Railway CLI.